### PR TITLE
Add user role management skeleton

### DIFF
--- a/.github/copilot-settings.json
+++ b/.github/copilot-settings.json
@@ -1,0 +1,9 @@
+{
+  "github.copilot.enable": { "*": true },
+  "github.copilot.inlineSuggest.enable": true,
+  "github.copilot.advanced.prompt": "Você é um desenvolvedor Python sênior. Gere código seguindo estas diretrizes: PEP8; use psycopg2 para conexão com PostgreSQL; no DAO (db_manager.py) não execute commit/rollback; na camada de serviço (role_manager.py) controle transações; implemente UI em PyQt6 conforme DDS; conecte signals e slots explicitamente; use dataclasses para entidades User e Group; configure logger global; mantenha comentários de documentação para cada método.",
+  "github.copilot.completion.maxTokens": 1000,
+  "github.copilot.completion.temperature": 0.2,
+  "github.copilot.suggestionDelay": 50,
+  "github.copilot.scopes": { "python": true }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/__init__.py
+++ b/__init__.py
@@ -2,4 +2,8 @@
 Arquivo principal do plugin GeoIFSC.
 """
 
-from .src.geoifsc.geoifsc_plugin import classFactory
+try:
+    from .src.geoifsc.geoifsc_plugin import classFactory
+except Exception:  # pragma: no cover - plugin deps podem faltar em testes
+    def classFactory(iface):  # type: ignore
+        return None

--- a/src/geoifsc/__init__.py
+++ b/src/geoifsc/__init__.py
@@ -22,3 +22,16 @@ def classFactory(iface):
     """
     from .geoifsc_plugin import GeoIFSCPlugin
     return GeoIFSCPlugin(iface)
+
+# Expor classes do módulo de gerenciamento de usuários
+from .db_manager import DBManager  # noqa: E402
+from .role_manager import RoleManager  # noqa: E402
+from .models import User, Group  # noqa: E402
+
+__all__ = [
+    "classFactory",
+    "DBManager",
+    "RoleManager",
+    "User",
+    "Group",
+]

--- a/src/geoifsc/db_manager.py
+++ b/src/geoifsc/db_manager.py
@@ -1,0 +1,122 @@
+"""Data Access Object for PostgreSQL roles."""
+from typing import List, Optional
+
+import psycopg2
+from psycopg2 import sql
+
+from .models import User, Group
+
+
+class DBManager:
+    """Encapsula operações no banco para usuários e grupos."""
+
+    def __init__(self, connection):
+        if connection is None:
+            raise ValueError("Conexão inválida")
+        self.conn = connection
+
+    # ---------------------- Métodos de Usuário ----------------------
+
+    def find_user_by_name(self, username: str) -> Optional[User]:
+        """Busca usuário pelo nome."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT rolname, rolvaliduntil, rolcanlogin
+                FROM pg_roles
+                WHERE rolname = %s
+                """,
+                (username,),
+            )
+            row = cur.fetchone()
+            if row:
+                return User(username=row[0], valid_until=row[1], can_login=row[2])
+        return None
+
+    def insert_user(self, username: str, password_hash: str) -> None:
+        """Cria um novo usuário."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE ROLE {} LOGIN PASSWORD %s").format(
+                    sql.Identifier(username)
+                ),
+                [password_hash],
+            )
+
+    def update_user(self, username: str, **fields) -> None:
+        """Atualiza atributos do usuário."""
+        with self.conn.cursor() as cur:
+            if "valid_until" in fields:
+                cur.execute(
+                    sql.SQL("ALTER ROLE {} VALID UNTIL %s").format(
+                        sql.Identifier(username)
+                    ),
+                    [fields["valid_until"],],
+                )
+            if "can_login" in fields:
+                action = "LOGIN" if fields["can_login"] else "NOLOGIN"
+                cur.execute(
+                    sql.SQL("ALTER ROLE {} %s").format(sql.Identifier(username)),
+                    [sql.SQL(action)],
+                )
+
+    def delete_user(self, username: str) -> None:
+        """Remove usuário."""
+        with self.conn.cursor() as cur:
+            cur.execute(sql.SQL("DROP ROLE {}" ).format(sql.Identifier(username)))
+
+    def list_users(self) -> List[str]:
+        """Lista usuários de acordo com filtros padrão."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT rolname
+                FROM pg_roles
+                WHERE rolname NOT LIKE 'pg_%' AND rolname <> 'postgres'
+                ORDER BY rolname
+                """
+            )
+            return [row[0] for row in cur.fetchall()]
+
+    # ---------------------- Métodos de Grupo ----------------------
+
+    def create_group(self, group_name: str) -> None:
+        """Cria grupo sem permissão de login."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE ROLE {} NOLOGIN").format(sql.Identifier(group_name))
+            )
+
+    def add_user_to_group(self, username: str, group_name: str) -> None:
+        """Adiciona usuário ao grupo."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("GRANT {} TO {}" ).format(
+                    sql.Identifier(group_name), sql.Identifier(username)
+                )
+            )
+
+    def remove_user_from_group(self, username: str, group_name: str) -> None:
+        """Remove usuário do grupo."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("REVOKE {} FROM {}" ).format(
+                    sql.Identifier(group_name), sql.Identifier(username)
+                )
+            )
+
+    def list_group_members(self, group_name: str) -> List[str]:
+        """Lista membros de um grupo."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT r.rolname
+                FROM pg_auth_members m
+                JOIN pg_roles r ON m.member = r.oid
+                JOIN pg_roles g ON m.roleid = g.oid
+                WHERE g.rolname = %s
+                ORDER BY r.rolname
+                """,
+                (group_name,),
+            )
+            return [row[0] for row in cur.fetchall()]

--- a/src/geoifsc/models.py
+++ b/src/geoifsc/models.py
@@ -1,0 +1,19 @@
+"""Data models for user management."""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class User:
+    """Representa um usuário do PostgreSQL."""
+
+    username: str
+    valid_until: Optional[str] = None
+    can_login: bool = True
+
+
+@dataclass
+class Group:
+    """Representa um grupo do PostgreSQL."""
+
+    name: str

--- a/src/geoifsc/role_manager.py
+++ b/src/geoifsc/role_manager.py
@@ -1,0 +1,114 @@
+"""Camada de serviços para gerenciamento de roles."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .db_manager import DBManager
+from .models import User
+
+
+class RoleManager:
+    """Regras de negócio para gerenciamento de usuários e grupos."""
+
+    def __init__(self, dao: DBManager, logger: Optional[logging.Logger] = None):
+        self.dao = dao
+        self.logger = logger or logging.getLogger(__name__)
+
+    # ---------------------- Operações de Usuário ----------------------
+
+    def create_user(self, username: str, password: str) -> str:
+        """Cria um novo usuário e persiste a transação."""
+        try:
+            self.dao.insert_user(username, password)
+            self.dao.conn.commit()
+            self.logger.info("Usuário %s criado", username)
+            return username
+        except Exception:
+            self.dao.conn.rollback()
+            self.logger.exception("Falha ao criar usuário %s", username)
+            raise
+
+    def get_user(self, username: str) -> Optional[User]:
+        """Obtém dados de um usuário."""
+        return self.dao.find_user_by_name(username)
+
+    def list_users(self) -> List[str]:
+        """Lista usuários registrados."""
+        return self.dao.list_users()
+
+    def update_user(self, username: str, **updates: Any) -> bool:
+        """Atualiza atributos de um usuário."""
+        try:
+            self.dao.update_user(username, **updates)
+            self.dao.conn.commit()
+            self.logger.info("Usuário %s atualizado", username)
+            return True
+        except Exception:
+            self.dao.conn.rollback()
+            self.logger.exception("Falha ao atualizar usuário %s", username)
+            raise
+
+    def delete_user(self, username: str) -> bool:
+        """Exclui usuário."""
+        try:
+            self.dao.delete_user(username)
+            self.dao.conn.commit()
+            self.logger.info("Usuário %s removido", username)
+            return True
+        except Exception:
+            self.dao.conn.rollback()
+            self.logger.exception("Falha ao remover usuário %s", username)
+            raise
+
+    def change_password(self, username: str, new_password: str) -> bool:
+        """Altera a senha de um usuário."""
+        try:
+            self.dao.update_user(username, password=new_password)
+            self.dao.conn.commit()
+            self.logger.info("Senha alterada para %s", username)
+            return True
+        except Exception:
+            self.dao.conn.rollback()
+            self.logger.exception("Falha ao alterar senha de %s", username)
+            raise
+
+    # ---------------------- Operações de Grupo ----------------------
+
+    def create_group(self, group_name: str) -> str:
+        """Cria um grupo."""
+        try:
+            self.dao.create_group(group_name)
+            self.dao.conn.commit()
+            self.logger.info("Grupo %s criado", group_name)
+            return group_name
+        except Exception:
+            self.dao.conn.rollback()
+            self.logger.exception("Falha ao criar grupo %s", group_name)
+            raise
+
+    def add_user_to_group(self, username: str, group_name: str) -> None:
+        """Adiciona usuário ao grupo."""
+        try:
+            self.dao.add_user_to_group(username, group_name)
+            self.dao.conn.commit()
+            self.logger.info("%s adicionado a %s", username, group_name)
+        except Exception:
+            self.dao.conn.rollback()
+            self.logger.exception("Falha ao adicionar %s ao grupo %s", username, group_name)
+            raise
+
+    def remove_user_from_group(self, username: str, group_name: str) -> None:
+        """Remove usuário do grupo."""
+        try:
+            self.dao.remove_user_from_group(username, group_name)
+            self.dao.conn.commit()
+            self.logger.info("%s removido de %s", username, group_name)
+        except Exception:
+            self.dao.conn.rollback()
+            self.logger.exception("Falha ao remover %s do grupo %s", username, group_name)
+            raise
+
+    def list_group_members(self, group_name: str) -> List[str]:
+        """Lista membros de um grupo."""
+        return self.dao.list_group_members(group_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,98 @@
+import sys
+import types
+import os
+
+# Ensure src directory is on path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+# Stub qgis modules if not available
+if 'qgis' not in sys.modules:
+    qgis = types.ModuleType('qgis')
+    core = types.ModuleType('qgis.core')
+    pyqt = types.ModuleType('qgis.PyQt')
+    qtwidgets = types.ModuleType('qgis.PyQt.QtWidgets')
+    qtgui = types.ModuleType('qgis.PyQt.QtGui')
+    qtcore = types.ModuleType('qgis.PyQt.QtCore')
+
+    class QAction: pass
+    class QMenu: pass
+    class QIcon: pass
+    class QTranslator: pass
+    class QCoreApplication:
+        @staticmethod
+        def installTranslator(t):
+            pass
+        @staticmethod
+        def translate(ctx, text):
+            return text
+    class QLocale:
+        @staticmethod
+        def system():
+            class L:
+                def name(self):
+                    return 'en_US'
+            return L()
+
+    class QgsMessageLog: pass
+    class Qgis: pass
+    class QgsApplication:
+        @staticmethod
+        def prefixPath():
+            return ''
+
+    qtwidgets.QAction = QAction
+    qtwidgets.QMenu = QMenu
+    qtgui.QIcon = QIcon
+    qtcore.QTranslator = QTranslator
+    qtcore.QCoreApplication = QCoreApplication
+    qtcore.QLocale = QLocale
+
+    core.QgsMessageLog = QgsMessageLog
+    core.Qgis = Qgis
+    core.QgsApplication = QgsApplication
+
+    qgis.core = core
+    pyqt.QtWidgets = qtwidgets
+    pyqt.QtGui = qtgui
+    pyqt.QtCore = qtcore
+    qgis.PyQt = pyqt
+
+    sys.modules['qgis'] = qgis
+    sys.modules['qgis.core'] = core
+    sys.modules['qgis.PyQt'] = pyqt
+    sys.modules['qgis.PyQt.QtWidgets'] = qtwidgets
+    sys.modules['qgis.PyQt.QtGui'] = qtgui
+    sys.modules['qgis.PyQt.QtCore'] = qtcore
+
+# Stub PyQt5 if not available
+if 'PyQt5' not in sys.modules:
+    class StubModule(types.ModuleType):
+        def __getattr__(self, name):
+            val = type(name, (), {})
+            setattr(self, name, val)
+            return val
+
+    pyqt5 = types.ModuleType('PyQt5')
+    QtWidgets5 = StubModule('PyQt5.QtWidgets')
+    QtGui5 = StubModule('PyQt5.QtGui')
+    QtCore5 = StubModule('PyQt5.QtCore')
+
+    QtGui5.QIcon = QIcon
+    def pyqtSignal(*args, **kwargs):
+        class _Sig:
+            def connect(self, *a, **k):
+                pass
+            def emit(self, *a, **k):
+                pass
+        return _Sig()
+
+    QtCore5.QObject = object
+    QtCore5.pyqtSignal = pyqtSignal
+
+    pyqt5.QtWidgets = QtWidgets5
+    pyqt5.QtGui = QtGui5
+    pyqt5.QtCore = QtCore5
+    sys.modules['PyQt5'] = pyqt5
+    sys.modules['PyQt5.QtWidgets'] = QtWidgets5
+    sys.modules['PyQt5.QtGui'] = QtGui5
+    sys.modules['PyQt5.QtCore'] = QtCore5

--- a/tests/test_role_manager.py
+++ b/tests/test_role_manager.py
@@ -1,0 +1,38 @@
+import pytest
+from unittest.mock import MagicMock
+
+from geoifsc.db_manager import DBManager
+from geoifsc.role_manager import RoleManager
+
+
+def make_conn():
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    return conn, cur
+
+
+def test_create_user_commits():
+    conn, cur = make_conn()
+    dao = DBManager(conn)
+    dao.insert_user = MagicMock()
+    manager = RoleManager(dao)
+
+    manager.create_user("user1", "pw")
+
+    dao.insert_user.assert_called_with("user1", "pw")
+    conn.commit.assert_called_once()
+    conn.rollback.assert_not_called()
+
+
+def test_create_user_rollback_on_error():
+    conn, cur = make_conn()
+    dao = DBManager(conn)
+    dao.insert_user = MagicMock(side_effect=Exception("fail"))
+    manager = RoleManager(dao)
+
+    with pytest.raises(Exception):
+        manager.create_user("user1", "pw")
+
+    conn.rollback.assert_called_once()
+    conn.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- add GitHub Copilot configuration
- ignore pycache files
- implement `User` and `Group` dataclasses
- create `DBManager` DAO with CRUD logic
- create `RoleManager` service layer
- export new classes in package init
- stub external Qt/QGIS modules for tests
- add unit tests for `RoleManager`
- allow plugin import to fail gracefully

## Testing
- `PYTHONPATH=src pytest -q` *(fails: tests/test_raster_uploader_service.py::test_path_injection_and_logging - AssertionError: assert '/tmp/pytest-of-root/pytest-3/test_path_injection_an...)*


------
https://chatgpt.com/codex/tasks/task_e_688ab60a57c8832e8c38f29b7ceedc32